### PR TITLE
Add ability to have multiple email addresses

### DIFF
--- a/core/components/formz/model/formz/formzhooks.class.php
+++ b/core/components/formz/model/formz/formzhooks.class.php
@@ -105,7 +105,8 @@ class formzHooks {
                 $newData['message'] .= $this->formArray[$field]['label'] . ' ' . $value . '<br>';
                 $newData[$this->formArray[$field]['id']] = $value;
             }
-
+            
+            $emailToAddresses = explode(',', $this->config->emailTo);
             $message = $this->fmz->getChunk($this->config->emailTpl, $newData);
 
             $this->modx->getService('mail', 'mail.modPHPMailer');
@@ -113,7 +114,9 @@ class formzHooks {
             $this->modx->mail->set(modMail::MAIL_FROM, $this->config->emailFrom);
             $this->modx->mail->set(modMail::MAIL_FROM_NAME, $this->config->senderName);
             $this->modx->mail->set(modMail::MAIL_SUBJECT, $this->config->subject);
-            $this->modx->mail->address('to', $this->config->emailTo);
+            foreach($emailToAddresses as $address) {
+              $this->modx->mail->address('to', trim($address));
+            }
             $this->modx->mail->address('reply-to', $this->config->emailFrom);
             $this->modx->mail->setHTML(true);
             if (!$this->modx->mail->send()) {


### PR DESCRIPTION
Not sure if I'm doing the pull request properly, so let me know if you want me to do something different, but this will allow multiple recipients for Formz forms. The UI already specifies "recipients", so no changes needed there. 
